### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", ruby-head]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", ruby-head]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true # 'bundle install' and cache gems
         ruby-version: ${{ matrix.ruby }}
+        bundler: 2.3.26
     - name: Run tests
       run: bundle exec rake


### PR DESCRIPTION
Also updates checkout action version. Runs green on my fork.

Bundler needs to be fixed at 2.3.26 because Bundler 2.4+ no longer supports Ruby 2.5.